### PR TITLE
Implement popSceneWithTransition method

### DIFF
--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -937,6 +937,34 @@ void Director::popScene()
     }
 }
 
+// Reference: https://discuss.cocos2d-x.org/t/tip-implement-popscene-with-transition/3647
+void Director::popSceneWithTransition(void)
+{
+    CCASSERT(_runningScene != nullptr, "running scene should not null");
+
+#if CC_ENABLE_GC_FOR_NATIVE_OBJECTS
+    auto sEngine = ScriptEngineManager::getInstance()->getScriptEngine();
+    if (sEngine)
+    {
+        sEngine->releaseScriptObject(this, _scenesStack.back());
+    }
+#endif // CC_ENABLE_GC_FOR_NATIVE_OBJECTS
+    _scenesStack.popBack();
+    ssize_t c = _scenesStack.size();
+    if (c == 0)
+    {
+        end();
+    }
+    else
+    {
+        _sendCleanupToScene = true;
+        _nextScene = _scenesStack.at(c - 1);
+        TransitionScene* trans = TransitionSlideInR::create(0.3f, _nextScene);
+        _scenesStack.replace(c-1, trans);
+        _nextScene = trans;
+    }
+}
+
 void Director::popToRootScene()
 {
     popToSceneStackLevel(1);

--- a/cocos/base/CCDirector.h
+++ b/cocos/base/CCDirector.h
@@ -308,6 +308,14 @@ public:
      */
     void popScene();
 
+    /**
+     * Pops out a scene from the stack with transition.
+     * This scene will replace the running one.
+     * The running scene will be deleted. If there are no more scenes in the stack the execution is terminated.
+     * ONLY call it if there is a running scene.
+     */
+    void popSceneWithTransition();
+
     /** 
      * Pops out all scenes from the stack until the root scene in the queue.
      * This scene will replace the running one.

--- a/cocos/scripting/js-bindings/auto/api/jsb_cocos2dx_auto_api.js
+++ b/cocos/scripting/js-bindings/auto/api/jsb_cocos2dx_auto_api.js
@@ -3264,6 +3264,14 @@ popScene : function (
 },
 
 /**
+ * @method popSceneWithTransition
+ */
+ popSceneWithTransition : function (
+)
+{
+},
+
+/**
  * @method loadIdentityMatrix
  * @param {cc.MATRIX_STACK_TYPE} arg0
  */

--- a/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.cpp
+++ b/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.cpp
@@ -7904,6 +7904,22 @@ bool js_cocos2dx_Director_popScene(JSContext *cx, uint32_t argc, jsval *vp)
     JS_ReportError(cx, "js_cocos2dx_Director_popScene : wrong number of arguments: %d, was expecting %d", argc, 0);
     return false;
 }
+bool js_cocos2dx_Director_popSceneWithTransition(JSContext *cx, uint32_t argc, jsval *vp)
+{
+    JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
+    JS::RootedObject obj(cx, args.thisv().toObjectOrNull());
+    js_proxy_t *proxy = jsb_get_js_proxy(obj);
+    cocos2d::Director* cobj = (cocos2d::Director *)(proxy ? proxy->ptr : NULL);
+    JSB_PRECONDITION2( cobj, cx, false, "js_cocos2dx_Director_popSceneWithTransition : Invalid Native Object");
+    if (argc == 0) {
+        cobj->popSceneWithTransition();
+        args.rval().setUndefined();
+        return true;
+    }
+
+    JS_ReportError(cx, "js_cocos2dx_Director_popSceneWithTransition : wrong number of arguments: %d, was expecting %d", argc, 0);
+    return false;
+}
 bool js_cocos2dx_Director_loadIdentityMatrix(JSContext *cx, uint32_t argc, jsval *vp)
 {
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
@@ -8403,6 +8419,7 @@ void js_register_cocos2dx_Director(JSContext *cx, JS::HandleObject global) {
         JS_FN("drawScene", js_cocos2dx_Director_drawScene, 0, JSPROP_PERMANENT | JSPROP_ENUMERATE),
         JS_FN("restart", js_cocos2dx_Director_restart, 0, JSPROP_PERMANENT | JSPROP_ENUMERATE),
         JS_FN("popScene", js_cocos2dx_Director_popScene, 0, JSPROP_PERMANENT | JSPROP_ENUMERATE),
+        JS_FN("popSceneWithTransition", js_cocos2dx_Director_popSceneWithTransition, 0, JSPROP_PERMANENT | JSPROP_ENUMERATE),
         JS_FN("loadIdentityMatrix", js_cocos2dx_Director_loadIdentityMatrix, 1, JSPROP_PERMANENT | JSPROP_ENUMERATE),
         JS_FN("isDisplayStats", js_cocos2dx_Director_isDisplayStats, 0, JSPROP_PERMANENT | JSPROP_ENUMERATE),
         JS_FN("setProjection", js_cocos2dx_Director_setProjection, 1, JSPROP_PERMANENT | JSPROP_ENUMERATE),


### PR DESCRIPTION
Pops out a scene from the queue with transition
This scene will replace the running one
The running scene will be deleted. If there are no more scenes in the stack the execution is terminated ONLY call it if there is a running scene.
Reference: https://discuss.cocos2d-x.org/t/tip-implement-popscene-with-transition/3647