### PR TITLE
update relinker to v1.4.4

### DIFF
--- a/cocos/platform/android/libcocos2dx/build.gradle
+++ b/cocos/platform/android/libcocos2dx/build.gradle
@@ -26,5 +26,5 @@ android {
 
 dependencies {
     implementation fileTree(dir: '../java/libs', include: ['*.jar'])
-    compile 'com.getkeepsafe.relinker:relinker:1.4.1'
+    compile 'com.getkeepsafe.relinker:relinker:1.4.4'
 }


### PR DESCRIPTION
relinker v1.4.1 was available under jcenter and we removed jcenter. 
From v1.4.4, relinker is available under mavencentral

ref:  https://github.com/KeepSafe/ReLinker/issues/90