### PR TITLE
Revert "Remove tinyxml2 from CCSaxParser implement. (#20141)"

### DIFF
--- a/cocos/platform/CCSAXParser.cpp
+++ b/cocos/platform/CCSAXParser.cpp
@@ -28,9 +28,65 @@
 #include <vector> // because its based on windows 8 build :P
 
 #include "platform/CCFileUtils.h"
+#include "tinyxml2.h"
 #include "rapidxml/rapidxml_sax3.hpp"
 
 NS_CC_BEGIN
+
+class XmlSaxHander : public tinyxml2::XMLVisitor
+{
+public:
+    XmlSaxHander():_ccsaxParserImp(0){};
+    
+    virtual bool VisitEnter( const tinyxml2::XMLElement& element, const tinyxml2::XMLAttribute* firstAttribute );
+    virtual bool VisitExit( const tinyxml2::XMLElement& element );
+    virtual bool Visit( const tinyxml2::XMLText& text );
+    virtual bool Visit( const tinyxml2::XMLUnknown&){ return true; }
+
+    void setSAXParserImp(SAXParser* parser)
+    {
+        _ccsaxParserImp = parser;
+    }
+
+private:
+    SAXParser *_ccsaxParserImp;
+};
+
+
+bool XmlSaxHander::VisitEnter( const tinyxml2::XMLElement& element, const tinyxml2::XMLAttribute* firstAttribute )
+{
+    //log(" VisitEnter %s",element.Value());
+
+    std::vector<const char*> attsVector;
+    for( const tinyxml2::XMLAttribute* attrib = firstAttribute; attrib; attrib = attrib->Next() )
+    {
+        //log("%s", attrib->Name());
+        attsVector.push_back(attrib->Name());
+        //log("%s",attrib->Value());
+        attsVector.push_back(attrib->Value());
+    }
+    
+    // nullptr is used in c++11
+    //attsVector.push_back(nullptr);
+    attsVector.push_back(nullptr);
+
+    SAXParser::startElement(_ccsaxParserImp, (const CC_XML_CHAR *)element.Value(), (const CC_XML_CHAR **)(&attsVector[0]));
+    return true;
+}
+bool XmlSaxHander::VisitExit( const tinyxml2::XMLElement& element )
+{
+    //log("VisitExit %s",element.Value());
+
+    SAXParser::endElement(_ccsaxParserImp, (const CC_XML_CHAR *)element.Value());
+    return true;
+}
+
+bool XmlSaxHander::Visit( const tinyxml2::XMLText& text )
+{
+    //log("Visit %s",text.Value());
+    SAXParser::textHandler(_ccsaxParserImp, (const CC_XML_CHAR *)text.Value(), strlen(text.Value()));
+    return true;
+}
 
 /// rapidxml SAX handler
 class RapidXmlSaxHander : public rapidxml::xml_sax2_handler
@@ -80,11 +136,12 @@ bool SAXParser::init(const char* /*encoding*/)
 
 bool SAXParser::parse(const char* xmlData, size_t dataLength)
 {
-    if(xmlData != nullptr && dataLength > 0) {
-        std::string mutableData(xmlData, dataLength);
-        return this->parseIntrusive(&mutableData.front(), dataLength);
-    }
-    return false;
+    tinyxml2::XMLDocument tinyDoc;
+    tinyDoc.Parse(xmlData, dataLength);
+    XmlSaxHander printer;
+    printer.setSAXParserImp(this);
+    
+    return tinyDoc.Accept( &printer );  
 }
 
 bool SAXParser::parse(const std::string& filename)
@@ -93,7 +150,7 @@ bool SAXParser::parse(const std::string& filename)
     Data data = FileUtils::getInstance()->getDataFromFile(filename);
     if (!data.isNull())
     {
-        ret = parseIntrusive((char*)data.getBytes(), data.getSize());
+        ret = parse((const char*)data.getBytes(), data.getSize());
     }
 
     return ret;


### PR DESCRIPTION
This reverts commit 4356cda555fae93714caabf5038bee6a158d1394.

Temporarily revert to tinyxml because of crash in rapidxml.