### PR TITLE
Disabling caching and reloading textures on opengl state loss

### DIFF
--- a/cocos/platform/CCPlatformMacros.h
+++ b/cocos/platform/CCPlatformMacros.h
@@ -87,7 +87,7 @@ CC_DEPRECATED_ATTRIBUTE static __TYPE__* node() \
  * @since v0.99.5
  */
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID) || (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT) 
-    #define CC_ENABLE_CACHE_TEXTURE_DATA       1
+    #define CC_ENABLE_CACHE_TEXTURE_DATA       0
 #else
     #define CC_ENABLE_CACHE_TEXTURE_DATA       0
 #endif

--- a/cocos/platform/android/javaactivity-android.cpp
+++ b/cocos/platform/android/javaactivity-android.cpp
@@ -106,11 +106,12 @@ JNIEXPORT void Java_org_cocos2dx_lib_Cocos2dxRenderer_nativeInit(JNIEnv*  env, j
         cocos2d::GL::invalidateStateCache();
         cocos2d::GLProgramCache::getInstance()->reloadDefaultGLPrograms();
         cocos2d::DrawPrimitives::init();
-        cocos2d::VolatileTextureMgr::reloadAllTextures();
-
         cocos2d::EventCustom recreatedEvent(EVENT_RENDERER_RECREATED);
         director->getEventDispatcher()->dispatchEvent(&recreatedEvent);
         director->setGLDefaultValues();
+#if CC_ENABLE_CACHE_TEXTURE_DATA
+        cocos2d::VolatileTextureMgr::reloadAllTextures();
+#endif
     }
     cocos2d::network::_preloadJavaDownloaderClass();
 }


### PR DESCRIPTION
Saves memory.
When app goes to bg, the textures are saved in memory and in case of an opengl context loss, the textures are restored which is definitely costly. This should improve performance