### PR TITLE
Enable support for restarting application process if OpenGL context i…

### DIFF
--- a/cocos/base/CCEventType.h
+++ b/cocos/base/CCEventType.h
@@ -45,5 +45,10 @@
 // This message is posted in cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxRenderer.cpp and cocos\platform\wp8-xaml\cpp\Cocos2dRenderer.cpp.
 #define EVENT_COME_TO_BACKGROUND    "event_come_to_background"
 
+// The application will be restarted.
+// This message is used for notifying application code of a pending application restart.
+// This message is posted in core/platform/android/javaactivity.cpp
+#define EVENT_APP_RESTARTING "event_app_restarting"
+
 /// @endcond
 #endif // __CCEVENT_TYPE_H__

--- a/cocos/platform/CCPlatformMacros.h
+++ b/cocos/platform/CCPlatformMacros.h
@@ -101,6 +101,16 @@ CC_DEPRECATED_ATTRIBUTE static __TYPE__* node() \
     #define CC_REBIND_INDICES_BUFFER  0
 #endif
 
+/** @def CC_ENABLE_RESTART_APPLICATION_ON_CONTEXT_LOST
+ * Enable this if application should be restarted after the OpenGL context is lost
+ *
+ */
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID && !CC_ENABLE_CACHE_TEXTURE_DATA)
+    #define CC_ENABLE_RESTART_APPLICATION_ON_CONTEXT_LOST 1
+#else
+    #define CC_ENABLE_RESTART_APPLICATION_ON_CONTEXT_LOST 0
+#endif
+
 // Generic macros
 
 /// @name namespace cocos2d

--- a/cocos/platform/android/java/src/com/jakewharton/processphoenix/ProcessPhoenix.java
+++ b/cocos/platform/android/java/src/com/jakewharton/processphoenix/ProcessPhoenix.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2014 Jake Wharton
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jakewharton.processphoenix;
+
+import android.app.Activity;
+import android.app.ActivityManager;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.Process;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK;
+import static android.content.Intent.FLAG_ACTIVITY_NEW_TASK;
+
+/**
+ * Process Phoenix facilitates restarting your application process. This should only be used for
+ * things like fundamental state changes in your debug builds (e.g., changing from staging to
+ * production).
+ * <p>
+ * Trigger process recreation by calling {@link #triggerRebirth} with a {@link Context} instance.
+ */
+public final class ProcessPhoenix extends Activity {
+    private static final String KEY_RESTART_INTENTS = "phoenix_restart_intents";
+    private static final String KEY_MAIN_PROCESS_PID = "phoenix_main_process_pid";
+
+    /**
+     * Call to restart the application process using the {@linkplain Intent#CATEGORY_DEFAULT default}
+     * activity as an intent.
+     * <p>
+     * Behavior of the current process after invoking this method is undefined.
+     */
+    public static void triggerRebirth(Context context) {
+        triggerRebirth(context, getRestartIntent(context));
+    }
+
+    /**
+     * Call to restart the application process using the specified intents.
+     * <p>
+     * Behavior of the current process after invoking this method is undefined.
+     */
+    public static void triggerRebirth(Context context, Intent... nextIntents) {
+        if (nextIntents.length < 1) {
+            throw new IllegalArgumentException("intents cannot be empty");
+        }
+        // create a new task for the first activity.
+        nextIntents[0].addFlags(FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_CLEAR_TASK);
+
+        Intent intent = new Intent(context, ProcessPhoenix.class);
+        intent.addFlags(FLAG_ACTIVITY_NEW_TASK); // In case we are called with non-Activity context.
+        intent.putParcelableArrayListExtra(KEY_RESTART_INTENTS, new ArrayList<>(Arrays.asList(nextIntents)));
+        intent.putExtra(KEY_MAIN_PROCESS_PID, Process.myPid());
+        context.startActivity(intent);
+    }
+
+    private static Intent getRestartIntent(Context context) {
+        String packageName = context.getPackageName();
+        Intent defaultIntent = context.getPackageManager().getLaunchIntentForPackage(packageName);
+        if (defaultIntent != null) {
+            return defaultIntent;
+        }
+
+        throw new IllegalStateException("Unable to determine default activity for "
+            + packageName
+            + ". Does an activity specify the DEFAULT category in its intent filter?");
+    }
+
+    @Override protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Process.killProcess(getIntent().getIntExtra(KEY_MAIN_PROCESS_PID, -1)); // Kill original main process
+
+        ArrayList<Intent> intents = getIntent().getParcelableArrayListExtra(KEY_RESTART_INTENTS);
+        startActivities(intents.toArray(new Intent[intents.size()]));
+        finish();
+        Runtime.getRuntime().exit(0); // Kill kill kill!
+    }
+
+    /**
+     * Checks if the current process is a temporary Phoenix Process.
+     * This can be used to avoid initialisation of unused resources or to prevent running code that
+     * is not multi-process ready.
+     *
+     * @return true if the current process is a temporary Phoenix Process
+     */
+    public static boolean isPhoenixProcess(Context context) {
+        int currentPid = Process.myPid();
+        ActivityManager manager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+        List<ActivityManager.RunningAppProcessInfo> runningProcesses = manager.getRunningAppProcesses();
+        if (runningProcesses != null) {
+            for (ActivityManager.RunningAppProcessInfo processInfo : runningProcesses) {
+                if (processInfo.pid == currentPid && processInfo.processName.endsWith(":phoenix")) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
@@ -60,6 +60,7 @@ import com.android.vending.expansion.zipfile.APKExpansionSupport;
 import com.android.vending.expansion.zipfile.ZipResourceFile;
 
 import com.enhance.gameservice.IGameTuningService;
+import com.jakewharton.processphoenix.ProcessPhoenix;
 
 import java.io.IOException;
 import java.io.File;
@@ -919,6 +920,10 @@ public class Cocos2dxHelper {
 
     public static int getSDKVersion() {
         return Build.VERSION.SDK_INT;
+    }
+
+    public static void restartProcess() {
+        ProcessPhoenix.triggerRebirth(sActivity);
     }
 
     private static Cocos2dxAccelerometer getAccelerometer() {

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxRenderer.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxRenderer.java
@@ -73,7 +73,12 @@ public class Cocos2dxRenderer implements GLSurfaceView.Renderer {
     public void onSurfaceCreated(final GL10 GL10, final EGLConfig EGLConfig) {
         Cocos2dxRenderer.nativeInit(this.mScreenWidth, this.mScreenHeight);
         this.mLastTickInNanoSeconds = System.nanoTime();
-        mNativeInitCompleted = true;
+        if (mNativeInitCompleted) {
+            // This must be from an OpenGL context loss
+            nativeOnContextLost();
+        } else {
+            mNativeInitCompleted = true;
+        }
     }
 
     @Override
@@ -119,6 +124,7 @@ public class Cocos2dxRenderer implements GLSurfaceView.Renderer {
     private static native boolean nativeKeyEvent(final int keyCode,boolean isPressed);
     private static native void nativeRender();
     private static native void nativeInit(final int width, final int height);
+    private static native void nativeOnContextLost();
     private static native void nativeOnSurfaceChanged(final int width, final int height);
     private static native void nativeOnPause();
     private static native void nativeOnResume();
@@ -149,12 +155,12 @@ public class Cocos2dxRenderer implements GLSurfaceView.Renderer {
 
     public void handleOnPause() {
         /**
-         * onPause may be invoked before onSurfaceCreated, 
+         * onPause may be invoked before onSurfaceCreated,
          * and engine will be initialized correctly after
          * onSurfaceCreated is invoked. Can not invoke any
          * native method before onSurfaceCreated is invoked
          */
-        if (! mNativeInitCompleted)
+        if (!mNativeInitCompleted)
             return;
 
         Cocos2dxHelper.onEnterBackground();

--- a/cocos/platform/android/javaactivity-android.cpp
+++ b/cocos/platform/android/javaactivity-android.cpp
@@ -115,6 +115,23 @@ JNIEXPORT void Java_org_cocos2dx_lib_Cocos2dxRenderer_nativeInit(JNIEnv*  env, j
     cocos2d::network::_preloadJavaDownloaderClass();
 }
 
+JNIEXPORT void JNICALL Java_org_cocos2dx_lib_Cocos2dxRenderer_nativeOnContextLost(JNIEnv*, jclass)
+{
+#if CC_ENABLE_RESTART_APPLICATION_ON_CONTEXT_LOST
+    auto director = cocos2d::Director::getInstance();
+    cocos2d::EventCustom recreatedEvent(EVENT_APP_RESTARTING);
+    director->getEventDispatcher()->dispatchEvent(&recreatedEvent);
+
+    //  Pop to root scene, replace with an empty scene, and clear all cached data before restarting
+    director->popToRootScene();
+    auto rootScene = Scene::create();
+    director->replaceScene(rootScene);
+    director->purgeCachedData();
+
+    JniHelper::callStaticVoidMethod("org/cocos2dx/lib/Cocos2dxHelper", "restartProcess");
+#endif
+}
+
 JNIEXPORT jintArray Java_org_cocos2dx_lib_Cocos2dxActivity_getGLContextAttrs(JNIEnv*  env, jobject thiz)
 {
     cocos2d::Application::getInstance()->initGLContextAttrs(); 

--- a/cocos/platform/android/libcocos2dx/AndroidManifest.xml
+++ b/cocos/platform/android/libcocos2dx/AndroidManifest.xml
@@ -1,5 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.cocos2dx.lib">
 
     <uses-permission android:name="android.permission.VIBRATE" />
+    <application>
+      <activity
+        android:name="com.jakewharton.processphoenix.ProcessPhoenix"
+        android:theme="@android:style/Theme.Translucent.NoTitleBar"
+        android:process=":phoenix"
+        android:exported="false"
+        />
+    </application>
 
 </manifest>


### PR DESCRIPTION
…s lost

Changes from -> https://github.com/axmolengine/axmol/pull/1409

Looks like other frameworks restart on context loss and cocos should do the same, A new event event_app_restarting is available for applications to listen to do their work if the state must be saved etc..